### PR TITLE
Clean dnf cache after installing packages

### DIFF
--- a/insights/Containerfile
+++ b/insights/Containerfile
@@ -1,6 +1,6 @@
 FROM registry.redhat.io/rhel9/rhel-bootc:9.4
 
-RUN dnf install rhc rhc-worker-playbook -y
+RUN dnf install rhc rhc-worker-playbook -y && dnf clean all
 
 # If you want the system to auto register to insights on first boot, uncomment
 # the next three statements and populate the .rhc_connect_credentials file


### PR DESCRIPTION
General best practice to clean the dnf cache before building container images to keep the size of the image as small as possible.